### PR TITLE
feat: Add configurable PBT iterations for local/CI environments

### DIFF
--- a/test/integration/comments_pbt_test.rb
+++ b/test/integration/comments_pbt_test.rb
@@ -29,7 +29,7 @@ class CommentsPbtTest < ActionDispatch::IntegrationTest
   test "create comment with random non-empty body succeeds" do
     login_as(@user)
 
-    20.times do
+    PBT_ITERATIONS.times do
       body_length = Rantly { range(1, 500) }
       body = Rantly { sized(body_length) { string } }
       body = "a" * body_length if body.empty? || body.strip.empty?
@@ -44,7 +44,7 @@ class CommentsPbtTest < ActionDispatch::IntegrationTest
   test "create comment with empty body fails" do
     login_as(@user)
 
-    10.times do
+    PBT_ITERATIONS.times do
       assert_no_difference "Comment.count" do
         post post_comments_path(@post), params: { comment: { body: "" } }
       end
@@ -71,7 +71,7 @@ class CommentsPbtTest < ActionDispatch::IntegrationTest
   # ============================================
 
   test "unauthenticated user cannot create comments with any data" do
-    15.times do
+    PBT_ITERATIONS.times do
       body = Rantly { sized(50) { string } }
       body = "Random comment" if body.empty?
 
@@ -87,7 +87,7 @@ class CommentsPbtTest < ActionDispatch::IntegrationTest
     comment = @post.comments.create!(user: @user, body: "Test comment")
     delete logout_path  # Logout
 
-    10.times do
+    PBT_ITERATIONS.times do
       assert_no_difference "Comment.count" do
         delete post_comment_path(@post, comment)
       end
@@ -102,7 +102,7 @@ class CommentsPbtTest < ActionDispatch::IntegrationTest
   test "user cannot delete other user's comment" do
     other_user = User.create!(name: "Other Commenter", email: "other_commenter@example.com", password: "password123")
 
-    10.times do
+    PBT_ITERATIONS.times do
       body = Rantly { sized(30) { string } }
       body = "Other's comment" if body.empty?
 
@@ -123,7 +123,7 @@ class CommentsPbtTest < ActionDispatch::IntegrationTest
   test "user can delete own comment with any body content" do
     login_as(@user)
 
-    10.times do
+    PBT_ITERATIONS.times do
       body = Rantly { sized(50) { string } }
       body = "My comment" if body.empty?
 
@@ -143,7 +143,7 @@ class CommentsPbtTest < ActionDispatch::IntegrationTest
   test "comments are correctly associated with posts" do
     login_as(@user)
 
-    10.times do
+    PBT_ITERATIONS.times do
       # Create multiple posts
       new_post = @user.posts.create!(
         title: Rantly { sized(20) { string(:alpha) } }.presence || "Random Post",
@@ -168,7 +168,7 @@ class CommentsPbtTest < ActionDispatch::IntegrationTest
   test "create comment with very long body (stress test)" do
     login_as(@user)
 
-    5.times do
+    PBT_ITERATIONS.times do
       body_length = Rantly { range(1000, 5000) }
       body = "a" * body_length
 

--- a/test/integration/posts_pbt_test.rb
+++ b/test/integration/posts_pbt_test.rb
@@ -33,7 +33,7 @@ class PostsPbtTest < ActionDispatch::IntegrationTest
   test "create post with valid random titles (1-255 chars) succeeds" do
     login_as(@user)
 
-    20.times do
+    PBT_ITERATIONS.times do
       title_length = Rantly { range(1, 255) }
       title = Rantly { sized(title_length) { string(:alpha) } }
       title = "a" * title_length if title.empty? || title.length != title_length
@@ -50,7 +50,7 @@ class PostsPbtTest < ActionDispatch::IntegrationTest
   test "create post with invalid titles (>255 chars) fails" do
     login_as(@user)
 
-    15.times do
+    PBT_ITERATIONS.times do
       title_length = Rantly { range(256, 500) }
       title = "a" * title_length
       body = "Valid body content"
@@ -65,7 +65,7 @@ class PostsPbtTest < ActionDispatch::IntegrationTest
   test "create post with empty title fails" do
     login_as(@user)
 
-    10.times do
+    PBT_ITERATIONS.times do
       body = Rantly { sized(100) { string } }
       body = "Some body content" if body.empty?
 
@@ -79,7 +79,7 @@ class PostsPbtTest < ActionDispatch::IntegrationTest
   test "create post with empty body fails" do
     login_as(@user)
 
-    10.times do
+    PBT_ITERATIONS.times do
       title = Rantly { sized(20) { string(:alpha) } }
       title = "Valid Title" if title.empty?
 
@@ -98,7 +98,7 @@ class PostsPbtTest < ActionDispatch::IntegrationTest
     login_as(@user)
     created_post = @user.posts.create!(title: "Original", body: "Original body")
 
-    15.times do
+    PBT_ITERATIONS.times do
       title_length = Rantly { range(1, 255) }
       new_title = "a" * title_length
       new_body = Rantly { sized(50) { string } }
@@ -117,7 +117,7 @@ class PostsPbtTest < ActionDispatch::IntegrationTest
     created_post = @user.posts.create!(title: "Original", body: "Original body")
     original_title = created_post.title
 
-    10.times do
+    PBT_ITERATIONS.times do
       title_length = Rantly { range(256, 400) }
       invalid_title = "a" * title_length
 
@@ -134,7 +134,7 @@ class PostsPbtTest < ActionDispatch::IntegrationTest
   # ============================================
 
   test "unauthenticated user cannot create posts with any data" do
-    10.times do
+    PBT_ITERATIONS.times do
       title = Rantly { sized(20) { string(:alpha) } }
       title = "Random Title" if title.empty?
       body = Rantly { sized(50) { string } }
@@ -151,7 +151,7 @@ class PostsPbtTest < ActionDispatch::IntegrationTest
     created_post = @user.posts.create!(title: "Original", body: "Original body")
     original_title = created_post.title
 
-    10.times do
+    PBT_ITERATIONS.times do
       new_title = Rantly { sized(20) { string(:alpha) } }
       new_title = "New Title" if new_title.empty?
 
@@ -174,7 +174,7 @@ class PostsPbtTest < ActionDispatch::IntegrationTest
 
     login_as(@user)
 
-    10.times do
+    PBT_ITERATIONS.times do
       new_title = Rantly { sized(20) { string(:alpha) } }
       new_title = "Attempted Title" if new_title.empty?
 
@@ -193,7 +193,7 @@ class PostsPbtTest < ActionDispatch::IntegrationTest
   test "title at exact boundary (255 chars) is valid" do
     login_as(@user)
 
-    5.times do
+    PBT_ITERATIONS.times do
       title = "a" * 255
       body = Rantly { sized(50) { string } }
       body = "Body content" if body.empty?
@@ -207,7 +207,7 @@ class PostsPbtTest < ActionDispatch::IntegrationTest
   test "title at boundary+1 (256 chars) is invalid" do
     login_as(@user)
 
-    5.times do
+    PBT_ITERATIONS.times do
       title = "a" * 256
       body = Rantly { sized(50) { string } }
       body = "Body content" if body.empty?

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,10 @@ ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require "rails/test_help"
 
+# Property-Based Testing iterations
+# CI runs more iterations for thorough testing, local runs fewer for speed
+PBT_ITERATIONS = ENV["CI"] ? 100 : 10
+
 module ActiveSupport
   class TestCase
     # Run tests in parallel with specified workers


### PR DESCRIPTION
## Overview
Add environment-aware iteration count for Property-Based Testing.

## Changes
### test/test_helper.rb
```ruby
# Property-Based Testing iterations
# CI runs more iterations for thorough testing, local runs fewer for speed
PBT_ITERATIONS = ENV["CI"] ? 100 : 10
```

### test/integration/posts_pbt_test.rb & comments_pbt_test.rb
- Replace hardcoded iteration counts (5, 10, 15, 20) with `PBT_ITERATIONS`
- All PBT loops now use the configurable constant

## Benefits
- **Local development**: Fast feedback with 10 iterations
- **CI pipeline**: Thorough testing with 100 iterations
- **Consistent behavior**: All PBT tests use the same iteration count

## Testing
- All 64 tests pass
- 1939 assertions total
- No failures or errors
